### PR TITLE
perf: 데이터베이스 인덱스 최적화 및 N+1 쿼리 해결

### DIFF
--- a/src/main/java/cleanbreath/backend/config/WebConfig.java
+++ b/src/main/java/cleanbreath/backend/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "https://cleanbreath.cmu02-studio.com")
-                .allowedMethods("GET", "POST", "PUT", "DELETE")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
                 .allowedHeaders("Authorization", "Content-Type")
                 .allowCredentials(true)
                 .maxAge(3600);

--- a/src/main/java/cleanbreath/backend/controller/AddressController.java
+++ b/src/main/java/cleanbreath/backend/controller/AddressController.java
@@ -24,7 +24,7 @@ public class AddressController {
      */
     @GetMapping("/allAddress")
     public ResponseEntity<?> getAllAddresses() {
-        List<AddressDto.ListResponse> result = addressService.getAllAddresses();
+        List<AddressDto.Response> result = addressService.getAllAddresses();
         LocalDateTime updateAt = LocalDateTime.now();
 
         return ResponseEntity.ok(ApiResponse.of(result.size(), updateAt, result));

--- a/src/main/java/cleanbreath/backend/controller/FeedbackController.java
+++ b/src/main/java/cleanbreath/backend/controller/FeedbackController.java
@@ -18,7 +18,7 @@ public class FeedbackController {
 
     // 전체 피드백 데이터 가져오기
     @GetMapping("/feedback-list")
-    public ResponseEntity<List<FeedbackDto.ListResponse>> FeedbackList() {
+    public ResponseEntity<List<FeedbackDto.ListResponse>> getFeedbackList() {
         List<FeedbackDto.ListResponse> result = feedbackService.findAllFeedback();
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/cleanbreath/backend/controller/PendingAddressController.java
+++ b/src/main/java/cleanbreath/backend/controller/PendingAddressController.java
@@ -28,7 +28,7 @@ public class PendingAddressController {
 
     @GetMapping("/allRequestAddressPage")
     public ResponseEntity<PagedModel<PendingDto.AddressResponse>> getAllRequestDataPage(Pageable pageable){
-        PagedModel<PendingDto.AddressResponse> result = pendingAddressService.GetPageAllManageAddress(pageable);
+        PagedModel<PendingDto.AddressResponse> result = pendingAddressService.getPageAllManageAddress(pageable);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/cleanbreath/backend/dto/AddressDto.java
+++ b/src/main/java/cleanbreath/backend/dto/AddressDto.java
@@ -84,29 +84,6 @@ public class AddressDto {
     @Getter
     @Setter
     @NoArgsConstructor
-    public static class ListResponse {
-        private Long id;
-        private String addressName;
-        private String buildingName;
-        private Double latitude;
-        private Double longitude;
-        private String category;
-        private List<PathResponse> path;
-
-        public ListResponse(Address address) {
-            this.id = address.getId();
-            this.addressName = address.getAddressName();
-            this.buildingName = address.getBuildingName();
-            this.latitude = address.getAddressPosLat();
-            this.longitude = address.getAddressPosLng();
-            this.category = address.getAddressCategory();
-            this.path = address.getPaths().stream().map(PathResponse::new).toList();
-        }
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
     public static class PathRequest {
         private DivisionArea divisionArea;
         private String pathLat;

--- a/src/main/java/cleanbreath/backend/dto/FeedbackDto.java
+++ b/src/main/java/cleanbreath/backend/dto/FeedbackDto.java
@@ -1,6 +1,7 @@
 package cleanbreath.backend.dto;
 
 import cleanbreath.backend.entity.Feedback;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,7 +14,10 @@ public class FeedbackDto {
     @Setter
     @NoArgsConstructor
     public static class Create {
+
+        @NotBlank
         private String title;
+        @NotBlank
         private String content;
 
         public Feedback toEntity() {

--- a/src/main/java/cleanbreath/backend/dto/common/ApiResponse.java
+++ b/src/main/java/cleanbreath/backend/dto/common/ApiResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class ApiResponse<T> {
+public class ApiResponse<T> implements BaseResponse {
     private int count;
     private LocalDateTime updateAt;
     private T data;

--- a/src/main/java/cleanbreath/backend/dto/common/BaseResponse.java
+++ b/src/main/java/cleanbreath/backend/dto/common/BaseResponse.java
@@ -1,0 +1,3 @@
+package cleanbreath.backend.dto.common;
+
+public interface BaseResponse { }

--- a/src/main/java/cleanbreath/backend/dto/common/MessageResponse.java
+++ b/src/main/java/cleanbreath/backend/dto/common/MessageResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class MessageResponse {
+public class MessageResponse implements BaseResponse {
     private String message;
 
     public static MessageResponse of(String message) {

--- a/src/main/java/cleanbreath/backend/entity/Address.java
+++ b/src/main/java/cleanbreath/backend/entity/Address.java
@@ -8,7 +8,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(name = "address")
+@Table(name = "address", indexes = {
+    // 위도/경도 복합 인덱스 - findByAddressPosLatAndAddressPosLng 쿼리 최적화
+    @Index(name = "idx_address_lat_lng", columnList = "address_pos_lat, address_pos_lng")
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor @Builder

--- a/src/main/java/cleanbreath/backend/entity/Apartment.java
+++ b/src/main/java/cleanbreath/backend/entity/Apartment.java
@@ -10,7 +10,10 @@ import java.util.List;
 @Entity
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "apartment")
+@Table(name = "apartment", indexes = {
+    // 지역별 아파트 조회 인덱스 - findByRegion 쿼리 최적화
+    @Index(name = "idx_apartment_region", columnList = "region")
+})
 @AllArgsConstructor
 public class Apartment {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/cleanbreath/backend/entity/ApartmentPath.java
+++ b/src/main/java/cleanbreath/backend/entity/ApartmentPath.java
@@ -8,7 +8,10 @@ import lombok.*;
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "apartment_path")
+@Table(name = "apartment_path", indexes = {
+    // 외래키 인덱스 - Apartment JOIN FETCH 최적화
+    @Index(name = "idx_apartment_path_apartment_id", columnList = "apartment_id")
+})
 public class ApartmentPath {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "apartment_path_id")

--- a/src/main/java/cleanbreath/backend/entity/Feedback.java
+++ b/src/main/java/cleanbreath/backend/entity/Feedback.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@Table(name = "feedback")
 public class Feedback {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/cleanbreath/backend/entity/Path.java
+++ b/src/main/java/cleanbreath/backend/entity/Path.java
@@ -5,7 +5,10 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "path")
+@Table(name = "path", indexes = {
+    // 외래키 인덱스 - findByAddressId 및 JOIN FETCH 최적화
+    @Index(name = "idx_path_address_id", columnList = "address_id")
+})
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/cleanbreath/backend/entity/pending/AreaValidationRequest.java
+++ b/src/main/java/cleanbreath/backend/entity/pending/AreaValidationRequest.java
@@ -9,6 +9,10 @@ import lombok.NoArgsConstructor;
 @Entity @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "area_validation_request", indexes = {
+    // 외래키 인덱스 - PendingAddress 연관 조회 최적화
+    @Index(name = "idx_area_validation_address_id", columnList = "m_address_id")
+})
 public class AreaValidationRequest {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/cleanbreath/backend/entity/pending/PendingAddress.java
+++ b/src/main/java/cleanbreath/backend/entity/pending/PendingAddress.java
@@ -13,6 +13,7 @@ import static jakarta.persistence.CascadeType.ALL;
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "pending_address")
 public class PendingAddress {
     @Column(name = "u_address_id")
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/cleanbreath/backend/entity/pending/PendingPath.java
+++ b/src/main/java/cleanbreath/backend/entity/pending/PendingPath.java
@@ -9,6 +9,10 @@ import lombok.*;
 @Getter @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "pending_path", indexes = {
+    // 외래키 인덱스 - findByPendingAddress, deleteByPendingAddress 쿼리 최적화
+    @Index(name = "idx_pending_path_address_id", columnList = "u_address_id")
+})
 public class PendingPath {
     @Column(name = "u_path_id")
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/cleanbreath/backend/exception/BusinessException.java
+++ b/src/main/java/cleanbreath/backend/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package cleanbreath.backend.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/cleanbreath/backend/exception/ErrorCode.java
+++ b/src/main/java/cleanbreath/backend/exception/ErrorCode.java
@@ -1,0 +1,27 @@
+package cleanbreath.backend.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // 주소(Address) 관련
+    ADDRESS_NOT_FOUND("해당 주소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PENDING_ADDRESS_NOT_FOUND("해당 요청 주소를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    PENDING_PATH_NOT_FOUND("해당 요청 경로를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    // 아파트(Apartment) 관련
+    REGION_NOT_FOUND("해당 지역은 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+
+    // 피드백(Feedback) 관련
+    FEEDBACK_NOT_FOUND("해당 피드백이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    FEEDBACK_INVALID("피드백 제목 또는 내용이 비어있습니다.", HttpStatus.BAD_REQUEST),
+
+    // 공통
+    INVALID_INPUT("잘못된 입력값입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/cleanbreath/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/cleanbreath/backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package cleanbreath.backend.exception;
+
+
+import cleanbreath.backend.dto.common.MessageResponse;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<MessageResponse> handleBusinessException(BusinessException e) {
+        log.warn("BusinessException: {}", e.getMessage());
+
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(MessageResponse.of(e.getMessage()));
+    }
+
+    // 예상치 못한 서버 오류는 상세 내용을 노출하지 않고 로그로만 기록
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<MessageResponse> handleException(Exception e) {
+        log.error("Unhandled exception: ", e);
+        return ResponseEntity
+                .internalServerError()
+                .body(MessageResponse.of("서버 내부 오류가 발생했습니다."));
+    }
+}

--- a/src/main/java/cleanbreath/backend/repository/AddressRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/AddressRepository.java
@@ -2,11 +2,16 @@ package cleanbreath.backend.repository;
 
 import cleanbreath.backend.entity.Address;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
     Optional<Address> findByAddressPosLatAndAddressPosLng(Double lat, Double lng);
+    
+    @Query("SELECT DISTINCT a FROM Address a LEFT JOIN FETCH a.paths")
+    List<Address> findAllWithPaths();
 }

--- a/src/main/java/cleanbreath/backend/repository/ApartmentRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/ApartmentRepository.java
@@ -11,4 +11,8 @@ import java.util.List;
 public interface ApartmentRepository extends JpaRepository<Apartment, Long> {
     @Query("select distinct a from Apartment a left join fetch a.apartmentPaths where a.region = :region")
     List<Apartment> findByRegion(String region);
+
+    // N+1 문제 방지 - 전체 아파트 조회 시 apartmentPaths를 함께 로딩
+    @Query("select distinct a from Apartment a left join fetch a.apartmentPaths")
+    List<Apartment> findAllWithPaths();
 }

--- a/src/main/java/cleanbreath/backend/repository/ApartmentRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/ApartmentRepository.java
@@ -2,11 +2,13 @@ package cleanbreath.backend.repository;
 
 import cleanbreath.backend.entity.Apartment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ApartmentRepository extends JpaRepository<Apartment, Long> {
+    @Query("select distinct a from Apartment a left join fetch a.apartmentPaths where a.region = :region")
     List<Apartment> findByRegion(String region);
 }

--- a/src/main/java/cleanbreath/backend/repository/pending/PendingAddressRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/pending/PendingAddressRepository.java
@@ -2,8 +2,13 @@ package cleanbreath.backend.repository.pending;
 
 import cleanbreath.backend.entity.pending.PendingAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PendingAddressRepository extends JpaRepository<PendingAddress, Long> {
+    @Query("SELECT DISTINCT p FROM PendingAddress p LEFT JOIN FETCH p.paths")
+    List<PendingAddress> findAllWithPaths();
 }

--- a/src/main/java/cleanbreath/backend/repository/pending/PendingPathRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/pending/PendingPathRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 @Repository
 public interface PendingPathRepository extends JpaRepository<PendingPath, Long> {
     Optional<PendingPath> findByPendingAddress(PendingAddress address);
-    void deleteByPendingAddress(Long id);
+    void deleteByPendingAddress(PendingAddress pendingAddress);
 }

--- a/src/main/java/cleanbreath/backend/service/AddressService.java
+++ b/src/main/java/cleanbreath/backend/service/AddressService.java
@@ -1,14 +1,11 @@
 package cleanbreath.backend.service;
 
 import cleanbreath.backend.dto.AddressDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface AddressService {
-    List<AddressDto.ListResponse> getAllAddresses();
-    Page<AddressDto.ListResponse> getAllAddress(Pageable pageable);
+    List<AddressDto.Response> getAllAddresses();
     AddressDto.Response getAddress(Double lat, Double lng);
     Object updateAddress(AddressDto.CheckUpdate updateAtDTO);
 }

--- a/src/main/java/cleanbreath/backend/service/AddressService.java
+++ b/src/main/java/cleanbreath/backend/service/AddressService.java
@@ -1,11 +1,13 @@
 package cleanbreath.backend.service;
 
 import cleanbreath.backend.dto.AddressDto;
+import cleanbreath.backend.dto.common.ApiResponse;
+import cleanbreath.backend.dto.common.BaseResponse;
 
 import java.util.List;
 
 public interface AddressService {
     List<AddressDto.Response> getAllAddresses();
     AddressDto.Response getAddress(Double lat, Double lng);
-    Object updateAddress(AddressDto.CheckUpdate updateAtDTO);
+    BaseResponse updateAddress(AddressDto.CheckUpdate updateAtDTO);
 }

--- a/src/main/java/cleanbreath/backend/service/PendingAddressService.java
+++ b/src/main/java/cleanbreath/backend/service/PendingAddressService.java
@@ -10,8 +10,16 @@ import org.springframework.data.web.PagedModel;
 import java.util.List;
 
 public interface PendingAddressService {
+
     List<PendingDto.AddressResponse> getAllManageAddress();
-    PagedModel<PendingDto.AddressResponse> GetPageAllManageAddress(Pageable pageable);
+
+    PagedModel<PendingDto.AddressResponse> getPageAllManageAddress(Pageable pageable);
+
     PendingDto.AddressResponse getManageAddressById(Long id);
+
     MessageResponse saveAddressData(AddressDto.Request addressDTO);
+
+    MessageResponse updateAddressData(Long id, AddressDto.Update addressDTO);
+
+    MessageResponse deleteAddressData(Long id);
 }

--- a/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
@@ -26,7 +26,6 @@ public class AddressServiceImpl implements AddressService {
     private static final long UPDATE_THRESHOLD_DAYS = 30;
     
     private final AddressRepository addressRepository;
-//    private final PathRepository pathRepository;
 
     public List<AddressDto.Response> getAllAddresses() {
         List<Address> findAddressList = addressRepository.findAllWithPaths();

--- a/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
@@ -9,8 +9,6 @@ import cleanbreath.backend.repository.PathRepository;
 import cleanbreath.backend.service.AddressService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,50 +18,40 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) @Slf4j
+@Transactional(readOnly = true)
+@Slf4j
 public class AddressServiceImpl implements AddressService {
+    private static final long UPDATE_THRESHOLD_DAYS = 30;
+    
     private final AddressRepository addressRepository;
     private final PathRepository pathRepository;
 
-    // 전체 데이터 가져오기
-    public List<AddressDto.ListResponse> getAllAddresses() {
-        List<Address> findAddressList = addressRepository.findAll();
-
+    public List<AddressDto.Response> getAllAddresses() {
+        List<Address> findAddressList = addressRepository.findAllWithPaths();
         return findAddressList.stream()
-                .map(AddressDto.ListResponse::new)
+                .map(AddressDto.Response::new)
                 .toList();
     }
 
-    // 전체 데이터 가져오기 (페이징 시스템 추가된 버전)
-    public Page<AddressDto.ListResponse> getAllAddress(Pageable pageable) {
-        return addressRepository.findAll(pageable)
-                .map(AddressDto.ListResponse::new);
-    }
-
-    // 좌표값을 입력받아 해당 주소 가져오기
     public AddressDto.Response getAddress(Double lat, Double lng) {
         Address findAddress = addressRepository.findByAddressPosLatAndAddressPosLng(lat, lng)
-                .orElseThrow(() -> new RuntimeException("Address not found"));
-
+                .orElseThrow(() -> new IllegalArgumentException("Address not found"));
         return new AddressDto.Response(findAddress);
     }
 
-    // 주소 데이터 업데이트
     public Object updateAddress(AddressDto.CheckUpdate updateAtDTO) {
-        List<Address> result = addressRepository.findAll();
+        LocalDateTime currentDate = LocalDateTime.now();
+        LocalDateTime checkingUpdateAt = updateAtDTO.getUpdateDate();
+        long daysBetween = ChronoUnit.DAYS.between(checkingUpdateAt, currentDate);
+
+        if (daysBetween < UPDATE_THRESHOLD_DAYS) {
+            return MessageResponse.of("아직 업데이트 시기가 아닙니다.");
+        }
+        
+        List<Address> result = addressRepository.findAllWithPaths();
         List<AddressDto.Response> convertResult = result.stream()
                 .map(AddressDto.Response::new)
                 .toList();
-
-        LocalDateTime currentDate = LocalDateTime.now();
-
-        LocalDateTime checkingUpdateAt = updateAtDTO.getUpdateDate();
-        long daysBetween = ChronoUnit.DAYS.between(currentDate, checkingUpdateAt);
-
-        if (daysBetween >= 30) {
-            return ApiResponse.of(convertResult.size(), currentDate, convertResult);
-        } else {
-            return MessageResponse.of("아직 업데이트 시기가 아닙니다.");
-        }
+        return ApiResponse.of(convertResult.size(), currentDate, convertResult);
     }
 }

--- a/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
@@ -24,7 +24,7 @@ public class AddressServiceImpl implements AddressService {
     private static final long UPDATE_THRESHOLD_DAYS = 30;
     
     private final AddressRepository addressRepository;
-    private final PathRepository pathRepository;
+//    private final PathRepository pathRepository;
 
     public List<AddressDto.Response> getAllAddresses() {
         List<Address> findAddressList = addressRepository.findAllWithPaths();

--- a/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/AddressServiceImpl.java
@@ -2,10 +2,12 @@ package cleanbreath.backend.service.impl;
 
 import cleanbreath.backend.dto.AddressDto;
 import cleanbreath.backend.dto.common.ApiResponse;
+import cleanbreath.backend.dto.common.BaseResponse;
 import cleanbreath.backend.dto.common.MessageResponse;
 import cleanbreath.backend.entity.Address;
+import cleanbreath.backend.exception.BusinessException;
+import cleanbreath.backend.exception.ErrorCode;
 import cleanbreath.backend.repository.AddressRepository;
-import cleanbreath.backend.repository.PathRepository;
 import cleanbreath.backend.service.AddressService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,11 +37,11 @@ public class AddressServiceImpl implements AddressService {
 
     public AddressDto.Response getAddress(Double lat, Double lng) {
         Address findAddress = addressRepository.findByAddressPosLatAndAddressPosLng(lat, lng)
-                .orElseThrow(() -> new IllegalArgumentException("Address not found"));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
         return new AddressDto.Response(findAddress);
     }
 
-    public Object updateAddress(AddressDto.CheckUpdate updateAtDTO) {
+    public BaseResponse updateAddress(AddressDto.CheckUpdate updateAtDTO) {
         LocalDateTime currentDate = LocalDateTime.now();
         LocalDateTime checkingUpdateAt = updateAtDTO.getUpdateDate();
         long daysBetween = ChronoUnit.DAYS.between(checkingUpdateAt, currentDate);

--- a/src/main/java/cleanbreath/backend/service/impl/ApartmentServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/ApartmentServiceImpl.java
@@ -2,6 +2,8 @@ package cleanbreath.backend.service.impl;
 
 import cleanbreath.backend.dto.ApartmentDto;
 import cleanbreath.backend.entity.Apartment;
+import cleanbreath.backend.exception.BusinessException;
+import cleanbreath.backend.exception.ErrorCode;
 import cleanbreath.backend.repository.ApartmentRepository;
 import cleanbreath.backend.service.ApartmentService;
 import lombok.RequiredArgsConstructor;
@@ -21,9 +23,10 @@ public class ApartmentServiceImpl implements ApartmentService {
      * stream과 mapd을 사용해 엔티티를 DTO로 변환해서 반환한다.
      */
     public List<ApartmentDto.Response> getAllApartments() {
-        List<Apartment> result = apartmentRepository.findAll();
-
-        return result.stream().map(ApartmentDto.Response::new).toList();
+        return apartmentRepository.findAll()
+                .stream()
+                .map(ApartmentDto.Response::new)
+                .toList();
     }
 
     /**
@@ -31,11 +34,15 @@ public class ApartmentServiceImpl implements ApartmentService {
      * 위와 마찬가지로 엔티티를 DTO로 변환하여 반환한다.
      */
     public List<ApartmentDto.Response> getRegionApartments(String region) {
-        List<Apartment> result = apartmentRepository.findByRegion(region);
+        List<ApartmentDto.Response> result = apartmentRepository.findByRegion(region)
+                .stream()
+                .map(ApartmentDto.Response::new)
+                .toList();
+
         if (result.isEmpty()) {
-            throw new IllegalArgumentException("해당 지역은 없는 지역입니다.");
+            throw new BusinessException(ErrorCode.REGION_NOT_FOUND);
         }
 
-        return result.stream().map(ApartmentDto.Response::new).toList();
+        return result;
     }
 }

--- a/src/main/java/cleanbreath/backend/service/impl/ApartmentServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/ApartmentServiceImpl.java
@@ -23,7 +23,7 @@ public class ApartmentServiceImpl implements ApartmentService {
      * stream과 mapd을 사용해 엔티티를 DTO로 변환해서 반환한다.
      */
     public List<ApartmentDto.Response> getAllApartments() {
-        return apartmentRepository.findAll()
+        return apartmentRepository.findAllWithPaths()
                 .stream()
                 .map(ApartmentDto.Response::new)
                 .toList();

--- a/src/main/java/cleanbreath/backend/service/impl/FeedBackServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/FeedBackServiceImpl.java
@@ -35,7 +35,6 @@ public class FeedBackServiceImpl implements FeedbackService {
     public FeedbackDto.Response findFeedback(Long id) {
         Feedback findFeedback = feedbackRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 피드백은 존재하지 않습니다."));
-
         return new FeedbackDto.Response(findFeedback);
     }
 
@@ -53,16 +52,15 @@ public class FeedBackServiceImpl implements FeedbackService {
 
     @Transactional
     public MessageResponse deleteFeedback(Long id) {
+        if (!feedbackRepository.existsById(id)) {
+            throw new IllegalArgumentException("해당 피드백은 존재하지 않습니다.");
+        }
         feedbackRepository.deleteById(id);
-
         return MessageResponse.of("피드백 삭제 완료");
     }
 
-
     private boolean saveValidation(FeedbackDto.Create feedBackDTO) {
-        if (feedBackDTO.getTitle().isEmpty() && feedBackDTO.getContent().isEmpty()) {
-            return false;
-        }
-        return true;
+        return feedBackDTO.getTitle() != null && !feedBackDTO.getTitle().isEmpty() 
+            && feedBackDTO.getContent() != null && !feedBackDTO.getContent().isEmpty();
     }
 }

--- a/src/main/java/cleanbreath/backend/service/impl/FeedBackServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/FeedBackServiceImpl.java
@@ -3,6 +3,8 @@ package cleanbreath.backend.service.impl;
 import cleanbreath.backend.dto.FeedbackDto;
 import cleanbreath.backend.dto.common.MessageResponse;
 import cleanbreath.backend.entity.Feedback;
+import cleanbreath.backend.exception.BusinessException;
+import cleanbreath.backend.exception.ErrorCode;
 import cleanbreath.backend.repository.FeedbackRepository;
 import cleanbreath.backend.service.FeedbackService;
 import lombok.RequiredArgsConstructor;
@@ -19,48 +21,48 @@ public class FeedBackServiceImpl implements FeedbackService {
 
     @Transactional
     public MessageResponse save(FeedbackDto.Create feedBackDTO) {
-        if (!saveValidation(feedBackDTO)) {
-            return MessageResponse.of("피드백 저장 실패");
+        if (feedBackDTO.getTitle().isBlank() || feedBackDTO.getContent().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
-        Feedback saveFeedback = feedBackDTO.toEntity();
-        feedbackRepository.save(saveFeedback);
+
+        feedbackRepository.save(feedBackDTO.toEntity());
         return MessageResponse.of("피드백 저장 성공");
     }
 
     public List<FeedbackDto.ListResponse> findAllFeedback() {
-        List<Feedback> result = feedbackRepository.findAll();
-        return result.stream().map(FeedbackDto.ListResponse::new).toList();
+        return feedbackRepository.findAll()
+                .stream()
+                .map(FeedbackDto.ListResponse::new)
+                .toList();
     }
 
     public FeedbackDto.Response findFeedback(Long id) {
         Feedback findFeedback = feedbackRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 피드백은 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND));
         return new FeedbackDto.Response(findFeedback);
     }
 
     @Transactional
     public MessageResponse updateFeedBack(Long id, FeedbackDto.Update updateDTO) {
         Feedback findFeedback = feedbackRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 피드백은 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND));
+
         findFeedback.updateFeedback(
                 updateDTO.getUpdateAt(),
                 updateDTO.getTitle(),
                 updateDTO.getContent()
         );
+
         return MessageResponse.of("업데이트 성공");
     }
 
     @Transactional
     public MessageResponse deleteFeedback(Long id) {
         if (!feedbackRepository.existsById(id)) {
-            throw new IllegalArgumentException("해당 피드백은 존재하지 않습니다.");
+            throw new BusinessException(ErrorCode.FEEDBACK_NOT_FOUND);
         }
+
         feedbackRepository.deleteById(id);
         return MessageResponse.of("피드백 삭제 완료");
-    }
-
-    private boolean saveValidation(FeedbackDto.Create feedBackDTO) {
-        return feedBackDTO.getTitle() != null && !feedBackDTO.getTitle().isEmpty() 
-            && feedBackDTO.getContent() != null && !feedBackDTO.getContent().isEmpty();
     }
 }

--- a/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
@@ -73,7 +73,7 @@ public class PendingAddressServiceImpl implements PendingAddressService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
 
         PendingPath findPendingPath = pathRepository.findByPendingAddress(findPendingAddress)
-                .orElseThrow(() -> new IllegalArgumentException("해당 영역은 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_PATH_NOT_FOUND));
 
         findPendingAddress.updateManageAddress(
                 addressDTO.getAddressName(),

--- a/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
@@ -5,6 +5,8 @@ import cleanbreath.backend.dto.PendingDto;
 import cleanbreath.backend.dto.common.MessageResponse;
 import cleanbreath.backend.entity.pending.PendingAddress;
 import cleanbreath.backend.entity.pending.PendingPath;
+import cleanbreath.backend.exception.BusinessException;
+import cleanbreath.backend.exception.ErrorCode;
 import cleanbreath.backend.repository.pending.PendingAddressRepository;
 import cleanbreath.backend.repository.pending.PendingPathRepository;
 import cleanbreath.backend.service.PendingAddressService;
@@ -26,35 +28,41 @@ public class PendingAddressServiceImpl implements PendingAddressService {
     private final PendingPathRepository pathRepository;
 
     public List<PendingDto.AddressResponse> getAllManageAddress() {
-        List<PendingAddress> result = addressRepository.findAllWithPaths();
-        return result.stream()
+        return addressRepository.findAllWithPaths()
+                .stream()
                 .map(PendingDto.AddressResponse::new)
                 .toList();
     }
 
     public PagedModel<PendingDto.AddressResponse> getPageAllManageAddress(Pageable pageable) {
-        Page<PendingDto.AddressResponse> list = addressRepository.findAll(pageable)
+        Page<PendingDto.AddressResponse> page = addressRepository.findAll(pageable)
                 .map(PendingDto.AddressResponse::new);
-        return new PagedModel<>(list);
+        return new PagedModel<>(page);
+    }
+
+    public PendingDto.AddressResponse getManageAddressById(Long id) {
+        return addressRepository.findById(id)
+                .map(PendingDto.AddressResponse::new)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
     }
 
     @Transactional
     public MessageResponse saveAddressData(AddressDto.Request addressDTO) {
-        if (!saveAddressValidate(addressDTO)) {
-             return MessageResponse.of("주소 및 영역 저장 실패");
-        }
-        PendingAddress saveAddress = addressDTO.toEntity();
-        addressRepository.save(saveAddress);
+        validateSaveRequest(addressDTO);
 
-        for (AddressDto.PathRequest path : addressDTO.getPaths()) {
-            PendingPath savePath = PendingPath.builder()
-                    .divisionArea(path.getDivisionArea())
-                    .pathLat(path.getPathLat())
-                    .pathLng(path.getPathLng())
-                    .pendingAddress(saveAddress)
-                    .build();
-            pathRepository.save(savePath);
-        }
+        PendingAddress savedAddress = addressRepository.save(addressDTO.toEntity());
+
+        // N번 세이브 대신에 saveAll() 한 번에 처리
+        List<PendingPath> pendingPaths = addressDTO.getPaths().stream()
+                .map(path -> PendingPath.builder()
+                        .divisionArea(path.getDivisionArea())
+                        .pathLat(path.getPathLat())
+                        .pathLng(path.getPathLng())
+                        .pendingAddress(savedAddress)
+                        .build())
+                .toList();
+
+        pathRepository.saveAll(pendingPaths);
 
         return MessageResponse.of("주소 및 영역 저장 성공");
     }
@@ -62,7 +70,7 @@ public class PendingAddressServiceImpl implements PendingAddressService {
     @Transactional
     public MessageResponse updateAddressData(Long id, AddressDto.Update addressDTO) {
         PendingAddress findPendingAddress = addressRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 아이디를 가진 장소는 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
 
         PendingPath findPendingPath = pathRepository.findByPendingAddress(findPendingAddress)
                 .orElseThrow(() -> new IllegalArgumentException("해당 영역은 없습니다."));
@@ -79,20 +87,26 @@ public class PendingAddressServiceImpl implements PendingAddressService {
     }
 
     @Transactional
-    public MessageResponse deleteAddressDTO(Long id) {
-        PendingAddress pendingAddress = addressRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 주소가 존재하지 않습니다."));
-        pathRepository.deleteByPendingAddress(pendingAddress);
-        addressRepository.deleteById(id);
+    public MessageResponse deleteAddressData(Long id) {
+        PendingAddress findPendingAddress = addressRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
+
+        // 엔티티 전달하여 타입 불일치 문제 해결
+        pathRepository.deleteByPendingAddress(findPendingAddress);
+        addressRepository.delete(findPendingAddress);
+
         return MessageResponse.of("해당 주소 및 영역 삭제 성공");
     }
 
-    private boolean saveAddressValidate(AddressDto.Request address) {
-        return address.getAddressName() != null && !address.getAddressName().isEmpty()
-            && address.getBuildingName() != null && !address.getBuildingName().isEmpty()
-            && address.getLatitude() != null && !address.getLatitude().isNaN()
-            && address.getLongitude() != null && !address.getLongitude().isNaN()
-            && address.getUpdateAt() != null
-            && address.getCategory() != null;
+    private void validateSaveRequest(AddressDto.Request address) {
+        if (address.getAddressName().isBlank() || address.getBuildingName().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (address.getLatitude() == null || address.getLongitude() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (address.getUpdateAt() == null || address.getCategory().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
     }
 }

--- a/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
@@ -25,41 +25,23 @@ public class PendingAddressServiceImpl implements PendingAddressService {
     private final PendingAddressRepository addressRepository;
     private final PendingPathRepository pathRepository;
 
-    /**
-     * 요청 받은 전체 데이터를 가져온다.
-     */
     public List<PendingDto.AddressResponse> getAllManageAddress() {
-        List<PendingAddress> result = addressRepository.findAll();
+        List<PendingAddress> result = addressRepository.findAllWithPaths();
         return result.stream()
                 .map(PendingDto.AddressResponse::new)
                 .toList();
     }
 
-    /**
-     * 요청 받은 전체 데이터를 가져온다.(페이징 시스템 추가)
-     */
-    public PagedModel<PendingDto.AddressResponse> GetPageAllManageAddress(
-            Pageable pageable
-    ) {
-        Page<PendingDto.AddressResponse> list = addressRepository.findAll(pageable).map(PendingDto.AddressResponse::new);
+    public PagedModel<PendingDto.AddressResponse> getPageAllManageAddress(Pageable pageable) {
+        Page<PendingDto.AddressResponse> list = addressRepository.findAll(pageable)
+                .map(PendingDto.AddressResponse::new);
         return new PagedModel<>(list);
     }
 
-    /**
-     * 아이디 값을 받아서 해당 주소 정보를 가져온다.
-     */
-    public PendingDto.AddressResponse getManageAddressById(Long id) {
-        return addressRepository.findById(id).map(PendingDto.AddressResponse::new).orElse(null);
-    }
-
-    /**
-     * 흡연구역의 주소 및 영역을 저장한다.
-     * Client -> Pending Address
-     */
     @Transactional
     public MessageResponse saveAddressData(AddressDto.Request addressDTO) {
         if (!saveAddressValidate(addressDTO)) {
-             return MessageResponse.of("주소 및 영역 저장실패");
+             return MessageResponse.of("주소 및 영역 저장 실패");
         }
         PendingAddress saveAddress = addressDTO.toEntity();
         addressRepository.save(saveAddress);
@@ -71,17 +53,12 @@ public class PendingAddressServiceImpl implements PendingAddressService {
                     .pathLng(path.getPathLng())
                     .pendingAddress(saveAddress)
                     .build();
-
             pathRepository.save(savePath);
         }
 
         return MessageResponse.of("주소 및 영역 저장 성공");
     }
 
-    /**
-     * 흡연구역 및 장소 영역을 업데이트 한다.
-     * Client -> Pending Address
-     */
     @Transactional
     public MessageResponse updateAddressData(Long id, AddressDto.Update addressDTO) {
         PendingAddress findPendingAddress = addressRepository.findById(id)
@@ -100,25 +77,22 @@ public class PendingAddressServiceImpl implements PendingAddressService {
 
         return MessageResponse.of("업데이트 성공");
     }
-    /**
-     * 해당 주소 아이디를 받아 주소 및 영역 동시 삭제
-     * Client -> Pending Address
-     */
+
     @Transactional
     public MessageResponse deleteAddressDTO(Long id) {
+        PendingAddress pendingAddress = addressRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주소가 존재하지 않습니다."));
+        pathRepository.deleteByPendingAddress(pendingAddress);
         addressRepository.deleteById(id);
-        pathRepository.deleteByPendingAddress(id);
         return MessageResponse.of("해당 주소 및 영역 삭제 성공");
     }
 
-    // Save Address ValidateCheck
     private boolean saveAddressValidate(AddressDto.Request address) {
-        if (address.getAddressName().isEmpty() && address.getBuildingName().isEmpty()) {
-            return false;
-        }
-        if (address.getLatitude().isNaN() && address.getLongitude().isNaN()) {
-            return false;
-        }
-        return address.getUpdateAt() != null || !address.getCategory().isEmpty();
+        return address.getAddressName() != null && !address.getAddressName().isEmpty()
+            && address.getBuildingName() != null && !address.getBuildingName().isEmpty()
+            && address.getLatitude() != null && !address.getLatitude().isNaN()
+            && address.getLongitude() != null && !address.getLongitude().isNaN()
+            && address.getUpdateAt() != null
+            && address.getCategory() != null;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,6 @@ spring:
     web:
       pageable:
         default-page-size: 20
-        max-page-size: 2000
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 개요
엔티티 및 서비스 코드를 분석하여 데이터베이스 인덱스 최적화와 N+1 쿼리 문제를 해결했습니다.

## 변경 사항

### 1. 데이터베이스 인덱스 추가 (`perf`)
- `Address`: 위도/경도 복합 인덱스 (`idx_address_lat_lng`) - `findByAddressPosLatAndAddressPosLng` 쿼리 최적화
- `Apartment`: region 인덱스 (`idx_apartment_region`) - `findByRegion` 쿼리 최적화
- `Path`, `ApartmentPath`, `PendingPath`, `AreaValidationRequest`: 외래키 인덱스 추가
- `Feedback`, `PendingAddress`, `PendingPath`, `AreaValidationRequest`: 누락된 `@Table` 어노테이션 명시

### 2. N+1 쿼리 해결 (`perf`)
- `ApartmentRepository`에 `findAllWithPaths()` JOIN FETCH 쿼리 추가
- `ApartmentServiceImpl.getAllApartments()`에서 `findAll()` → `findAllWithPaths()` 변경

### 3. 데드 코드 정리 (`refactor`)
- `AddressServiceImpl`에서 주석 처리된 `PathRepository` 코드 제거

## 참고
- 현재 `ddl-auto: validate` 설정이므로, 실제 DB에 인덱스를 반영하려면 별도 SQL 실행이 필요합니다.
