### PR TITLE
feat: 구역 진위 투표 및 주소 승인 배치 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	testImplementation 'org.springframework.batch:spring-batch-test'
+
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/cleanbreath/backend/CleanBreathBackendApplication.java
+++ b/src/main/java/cleanbreath/backend/CleanBreathBackendApplication.java
@@ -2,8 +2,10 @@ package cleanbreath.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CleanBreathBackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/cleanbreath/backend/batch/AddressPromotionBatchConfig.java
+++ b/src/main/java/cleanbreath/backend/batch/AddressPromotionBatchConfig.java
@@ -1,0 +1,112 @@
+package cleanbreath.backend.batch;
+
+import cleanbreath.backend.entity.Address;
+import cleanbreath.backend.entity.Path;
+import cleanbreath.backend.entity.pending.PendingAddress;
+import cleanbreath.backend.repository.AddressRepository;
+import cleanbreath.backend.repository.PathRepository;
+import cleanbreath.backend.repository.pending.PendingAddressRepository;
+import cleanbreath.backend.repository.pending.PendingPathRepository;
+import cleanbreath.backend.repository.pending.SmokingAreaValidateRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 매일 새벽 3시에 실행되는 배치 설정.
+ * 검증 투표(truth)가 임계값 이상인 PendingAddress를 Address 테이블로 승격시킵니다.
+ */
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class AddressPromotionBatchConfig {
+
+    private final PendingAddressRepository pendingAddressRepository;
+    private final PendingPathRepository pendingPathRepository;
+    private final SmokingAreaValidateRepository validationRepository;
+    private final AddressRepository addressRepository;
+    private final PathRepository pathRepository;
+
+    @Value("${batch.promotion.threshold}")
+    private int promotionThreshold;
+
+    @Bean
+    public Job addressPromotionJob(JobRepository jobRepository, Step addressPromotionStep) {
+        return new JobBuilder("addressPromotionJob", jobRepository)
+            .start(addressPromotionStep)
+            .build();
+    }
+
+    @Bean
+    public Step addressPromotionStep(JobRepository jobRepository,
+                                     PlatformTransactionManager transactionManager) {
+        return new StepBuilder("addressPromotionStep", jobRepository)
+            .tasklet(addressPromotionTasklet(), transactionManager)
+            .build();
+    }
+
+    @Bean
+    public Tasklet addressPromotionTasklet() {
+        return (contribution, chunkContext) -> {
+            List<PendingAddress> qualified =
+                pendingAddressRepository.findAddressesMeetingThreshold(promotionThreshold);
+
+            if (qualified.isEmpty()) {
+                log.info("[배치] 승격 대상 주소 없음 (임계값: {})", promotionThreshold);
+                return RepeatStatus.FINISHED;
+            }
+
+            log.info("[배치] 승격 대상 주소 {}건 발견 (임계값: {})", qualified.size(), promotionThreshold);
+
+            for (PendingAddress pending : qualified) {
+                // PendingAddress → Address 변환
+                Address address = Address.builder()
+                    .updateAt(LocalDateTime.now())
+                    .addressName(pending.getAddressName())
+                    .buildingName(pending.getBuildingName())
+                    .addressPosLat(pending.getAddressPosLat())
+                    .addressPosLng(pending.getAddressPosLng())
+                    .addressCategory(pending.getAddressCategory())
+                    .build();
+
+                Address savedAddress = addressRepository.save(address);
+
+                // PendingPath → Path 변환 (DivisionArea 기준으로 금연/흡연 구역 구분)
+                List<Path> paths = pending.getPaths().stream()
+                    .map(pendingPath -> Path.builder()
+                        .address(savedAddress)
+                        .divisionArea(pendingPath.getDivisionArea())
+                        .pathLat(pendingPath.getPathLat())
+                        .pathLng(pendingPath.getPathLng())
+                        .build())
+                    .toList();
+
+                pathRepository.saveAll(paths);
+
+                // 승격 완료 후 Pending 데이터 정리
+                validationRepository.deleteByPendingAddress(pending);
+                pendingPathRepository.deleteByPendingAddress(pending);
+                pendingAddressRepository.delete(pending);
+
+                log.info("[배치] 주소 승격 완료: {} ({})",
+                    pending.getAddressName(), pending.getBuildingName());
+            }
+
+            log.info("[배치] 총 {}건 승격 완료", qualified.size());
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/src/main/java/cleanbreath/backend/batch/AddressPromotionScheduler.java
+++ b/src/main/java/cleanbreath/backend/batch/AddressPromotionScheduler.java
@@ -1,0 +1,42 @@
+package cleanbreath.backend.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobOperator;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매일 새벽 3시에 주소 승격 배치를 실행하는 스케줄러.
+ * Spring Batch 5.x 권장 방식인 JobOperator를 사용합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AddressPromotionScheduler {
+
+  private final JobOperator jobOperator;
+  private final Job addressPromotionJob;
+
+  // 매일 새벽 3시 실행
+  @Scheduled(cron = "${batch.promotion.cron:0 0 3 * * *}")
+  public void runPromotionBatch() {
+    try {
+      // 매 실행마다 고유한 JobParameters 생성
+      JobParameters params = new JobParametersBuilder()
+          .addLong("executionTime", System.currentTimeMillis())
+          .toJobParameters();
+
+      JobExecution executionId = jobOperator.start(addressPromotionJob, params);
+      log.info("[스케줄러] 주소 승격 배치 실행 완료 (executionId: {})",
+          executionId);
+    } catch (Exception e) {
+      log.error("[스케줄러] 주소 승격 배치 실행 실패: {}",
+          e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/cleanbreath/backend/controller/PendingAddressController.java
+++ b/src/main/java/cleanbreath/backend/controller/PendingAddressController.java
@@ -32,6 +32,20 @@ public class PendingAddressController {
         return ResponseEntity.ok(result);
     }
 
+    @GetMapping("/smokingArea/{id}")
+    public ResponseEntity<PendingDto.DetailResponse> getAreaDetail(@PathVariable Long id) {
+        PendingDto.DetailResponse result = pendingAddressService.getAddressDetail(id);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/smokingArea/{id}/vote")
+    public ResponseEntity<MessageResponse> voteArea(
+            @PathVariable Long id,
+            @RequestBody PendingDto.ValidationVoteRequest request) {
+        MessageResponse message = pendingAddressService.vote(id, request);
+        return ResponseEntity.ok(message);
+    }
+
     @PostMapping("/smokingArea/add")
     public ResponseEntity<MessageResponse> addSmokingArea(@RequestBody AddressDto.Request requestSmokingArea) {
         MessageResponse message = pendingAddressService.saveAddressData(requestSmokingArea);

--- a/src/main/java/cleanbreath/backend/dto/PendingDto.java
+++ b/src/main/java/cleanbreath/backend/dto/PendingDto.java
@@ -37,6 +37,51 @@ public class PendingDto {
         }
     }
 
+    /**
+     * 구역 상세 조회 응답 (메타데이터 + 영역 데이터 + 진위 투표 수)
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class DetailResponse {
+        private Long id;
+        private String addressName;
+        private String buildingName;
+        private Double latitude;
+        private Double longitude;
+        private String category;
+        private List<PathResponse> paths;
+        private int truthCount;
+        private int untruthCount;
+
+        public DetailResponse(PendingAddress pendingAddress,
+                              int truthCount, int untruthCount) {
+            this.id = pendingAddress.getId();
+            this.addressName = pendingAddress.getAddressName();
+            this.buildingName = pendingAddress.getBuildingName();
+            this.latitude = pendingAddress.getAddressPosLat();
+            this.longitude = pendingAddress.getAddressPosLng();
+            this.category = pendingAddress.getAddressCategory();
+            this.paths = pendingAddress.getPaths()
+                    .stream()
+                    .map(PathResponse::new)
+                    .toList();
+            this.truthCount = truthCount;
+            this.untruthCount = untruthCount;
+        }
+    }
+
+    /**
+     * 진위 투표 요청
+     */
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ValidationVoteRequest {
+        private String clientToken;
+        private boolean isTruth;
+    }
+
     @Getter
     @Setter
     @NoArgsConstructor

--- a/src/main/java/cleanbreath/backend/entity/pending/AreaValidationRequest.java
+++ b/src/main/java/cleanbreath/backend/entity/pending/AreaValidationRequest.java
@@ -9,10 +9,16 @@ import lombok.NoArgsConstructor;
 @Entity @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table(name = "area_validation_request", indexes = {
-    // 외래키 인덱스 - PendingAddress 연관 조회 최적화
-    @Index(name = "idx_area_validation_address_id", columnList = "m_address_id")
-})
+@Table(name = "area_validation_request",
+    uniqueConstraints = {
+        // 동일 클라이언트가 같은 대상에 중복 투표 방지
+        @UniqueConstraint(name = "uk_client_token_target_id", columnNames = {"client_token", "target_id"})
+    },
+    indexes = {
+        // 외래키 인덱스 - PendingAddress 연관 조회 최적화
+        @Index(name = "idx_area_validation_address_id", columnList = "m_address_id")
+    }
+)
 public class AreaValidationRequest {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -21,6 +27,14 @@ public class AreaValidationRequest {
     @JoinColumn(name = "m_address_id")
     private PendingAddress pendingAddress;
 
-    private int truth; // 흡연구역 판별 숫자
-    private int untruth; // 금연구역 판별 숫자
+    // 프론트엔드에서 생성한 랜덤 토큰 (중복 투표 방지용)
+    @Column(name = "client_token", nullable = false)
+    private String clientToken;
+
+    // 투표 대상 ID
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    private int truth; // 판별 숫자
+    private int untruth; // 판별 숫자
 }

--- a/src/main/java/cleanbreath/backend/exception/ErrorCode.java
+++ b/src/main/java/cleanbreath/backend/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
     FEEDBACK_INVALID("피드백 제목 또는 내용이 비어있습니다.", HttpStatus.BAD_REQUEST),
 
     // 공통
-    INVALID_INPUT("잘못된 입력값입니다.", HttpStatus.BAD_REQUEST);
+    INVALID_INPUT("잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
+    DUPLICATE_VALIDATION_REQUEST("이미 해당 대상에 대한 검증 요청이 존재합니다.", HttpStatus.CONFLICT);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/cleanbreath/backend/repository/pending/PendingAddressRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/pending/PendingAddressRepository.java
@@ -3,6 +3,7 @@ package cleanbreath.backend.repository.pending;
 import cleanbreath.backend.entity.pending.PendingAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,4 +12,14 @@ import java.util.List;
 public interface PendingAddressRepository extends JpaRepository<PendingAddress, Long> {
     @Query("SELECT DISTINCT p FROM PendingAddress p LEFT JOIN FETCH p.paths")
     List<PendingAddress> findAllWithPaths();
+
+    // 검증 투표(truth) 합계가 임계값 이상인 PendingAddress 조회 (배치용)
+    @Query("""
+        SELECT DISTINCT pa FROM PendingAddress pa
+        LEFT JOIN FETCH pa.paths
+        JOIN pa.areaValidationRequests avr
+        GROUP BY pa
+        HAVING SUM(avr.truth) >= :threshold
+    """)
+    List<PendingAddress> findAddressesMeetingThreshold(@Param("threshold") int threshold);
 }

--- a/src/main/java/cleanbreath/backend/repository/pending/SmokingAreaValidateRepository.java
+++ b/src/main/java/cleanbreath/backend/repository/pending/SmokingAreaValidateRepository.java
@@ -1,9 +1,25 @@
 package cleanbreath.backend.repository.pending;
 
 import cleanbreath.backend.entity.pending.AreaValidationRequest;
+import cleanbreath.backend.entity.pending.PendingAddress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SmokingAreaValidateRepository extends JpaRepository<AreaValidationRequest, Long> {
+    // 동일 클라이언트 토큰 + 대상 ID 중복 체크
+    boolean existsByClientTokenAndTargetId(String clientToken, Long targetId);
+
+    // 특정 PendingAddress에 대한 검증 요청 삭제 (배치 승인 후 정리용)
+    void deleteByPendingAddress(PendingAddress pendingAddress);
+
+    // 특정 PendingAddress에 대한 truth 합계
+    @Query("SELECT COALESCE(SUM(a.truth), 0) FROM AreaValidationRequest a WHERE a.pendingAddress.id = :addressId")
+    int sumTruthByPendingAddressId(@Param("addressId") Long addressId);
+
+    // 특정 PendingAddress에 대한 untruth 합계
+    @Query("SELECT COALESCE(SUM(a.untruth), 0) FROM AreaValidationRequest a WHERE a.pendingAddress.id = :addressId")
+    int sumUntruthByPendingAddressId(@Param("addressId") Long addressId);
 }

--- a/src/main/java/cleanbreath/backend/service/PendingAddressService.java
+++ b/src/main/java/cleanbreath/backend/service/PendingAddressService.java
@@ -3,7 +3,6 @@ package cleanbreath.backend.service;
 import cleanbreath.backend.dto.AddressDto;
 import cleanbreath.backend.dto.PendingDto;
 import cleanbreath.backend.dto.common.MessageResponse;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 
@@ -16,6 +15,10 @@ public interface PendingAddressService {
     PagedModel<PendingDto.AddressResponse> getPageAllManageAddress(Pageable pageable);
 
     PendingDto.AddressResponse getManageAddressById(Long id);
+
+    PendingDto.DetailResponse getAddressDetail(Long id);
+
+    MessageResponse vote(Long addressId, PendingDto.ValidationVoteRequest request);
 
     MessageResponse saveAddressData(AddressDto.Request addressDTO);
 

--- a/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
+++ b/src/main/java/cleanbreath/backend/service/impl/PendingAddressServiceImpl.java
@@ -3,12 +3,14 @@ package cleanbreath.backend.service.impl;
 import cleanbreath.backend.dto.AddressDto;
 import cleanbreath.backend.dto.PendingDto;
 import cleanbreath.backend.dto.common.MessageResponse;
+import cleanbreath.backend.entity.pending.AreaValidationRequest;
 import cleanbreath.backend.entity.pending.PendingAddress;
 import cleanbreath.backend.entity.pending.PendingPath;
 import cleanbreath.backend.exception.BusinessException;
 import cleanbreath.backend.exception.ErrorCode;
 import cleanbreath.backend.repository.pending.PendingAddressRepository;
 import cleanbreath.backend.repository.pending.PendingPathRepository;
+import cleanbreath.backend.repository.pending.SmokingAreaValidateRepository;
 import cleanbreath.backend.service.PendingAddressService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,6 +28,7 @@ public class PendingAddressServiceImpl implements PendingAddressService {
 
     private final PendingAddressRepository addressRepository;
     private final PendingPathRepository pathRepository;
+    private final SmokingAreaValidateRepository validationRepository;
 
     public List<PendingDto.AddressResponse> getAllManageAddress() {
         return addressRepository.findAllWithPaths()
@@ -44,6 +47,40 @@ public class PendingAddressServiceImpl implements PendingAddressService {
         return addressRepository.findById(id)
                 .map(PendingDto.AddressResponse::new)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
+    }
+
+    public PendingDto.DetailResponse getAddressDetail(Long id) {
+        PendingAddress pendingAddress = addressRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
+
+        int truthCount = validationRepository.sumTruthByPendingAddressId(id);
+        int untruthCount = validationRepository.sumUntruthByPendingAddressId(id);
+
+        return new PendingDto.DetailResponse(pendingAddress, truthCount, untruthCount);
+    }
+
+    @Transactional
+    public MessageResponse vote(Long addressId, PendingDto.ValidationVoteRequest request) {
+        // 중복 투표 방지 (client_token + target_id UNIQUE)
+        if (validationRepository.existsByClientTokenAndTargetId(
+                request.getClientToken(), addressId)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_VALIDATION_REQUEST);
+        }
+
+        PendingAddress pendingAddress = addressRepository.findById(addressId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PENDING_ADDRESS_NOT_FOUND));
+
+        AreaValidationRequest validationRequest = AreaValidationRequest.builder()
+                .pendingAddress(pendingAddress)
+                .clientToken(request.getClientToken())
+                .targetId(addressId)
+                .truth(request.isTruth() ? 1 : 0)
+                .untruth(request.isTruth() ? 0 : 1)
+                .build();
+
+        validationRepository.save(validationRequest);
+
+        return MessageResponse.of("투표가 완료되었습니다.");
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,20 @@ spring:
       hibernate:
         show_sql: false
         format_sql: false
+
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false
+
+batch:
+  promotion:
+    threshold: 20 # 임계값 20으로 수정
+    cron: "0 0 3 * * *"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, monitoring, metrics

--- a/src/test/java/cleanbreath/backend/batch/AddressPromotionSchedulerTest.java
+++ b/src/test/java/cleanbreath/backend/batch/AddressPromotionSchedulerTest.java
@@ -1,0 +1,60 @@
+package cleanbreath.backend.batch;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.launch.JobOperator;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * AddressPromotionScheduler 단위 테스트.
+ * Given-When-Then 패턴 + FIRST 원칙 적용.
+ */
+@ExtendWith(MockitoExtension.class)
+class AddressPromotionSchedulerTest {
+
+  @Mock private JobOperator jobOperator;
+  @Mock private Job addressPromotionJob;
+  @Mock private JobExecution jobExecution;
+
+  @InjectMocks
+  private AddressPromotionScheduler scheduler;
+
+  @Test
+  @DisplayName("스케줄러 실행 시 JobOperator.start()가 호출된다")
+  void shouldCallJobOperatorStart() throws Exception {
+    // Given: JobOperator가 정상 동작
+    given(jobOperator.start(eq(addressPromotionJob), any(JobParameters.class)))
+        .willReturn(jobExecution);
+
+    // When: 스케줄러 실행
+    scheduler.runPromotionBatch();
+
+    // Then: JobOperator.start()가 Job과 JobParameters로 호출됨
+    verify(jobOperator).start(eq(addressPromotionJob), any(JobParameters.class));
+  }
+
+  @Test
+  @DisplayName("배치 실행 중 예외 발생 시 예외가 전파되지 않는다")
+  void shouldNotPropagateExceptionOnFailure() throws Exception {
+    // Given: JobOperator가 예외를 던짐
+    given(jobOperator.start(eq(addressPromotionJob), any(JobParameters.class)))
+        .willThrow(new RuntimeException("배치 실행 실패"));
+
+    // When & Then: 예외가 전파되지 않음 (catch 처리)
+    scheduler.runPromotionBatch();
+
+    // 메서드가 정상 종료되면 테스트 통과
+    verify(jobOperator).start(eq(addressPromotionJob), any(JobParameters.class));
+  }
+}

--- a/src/test/java/cleanbreath/backend/batch/AddressPromotionTaskletTest.java
+++ b/src/test/java/cleanbreath/backend/batch/AddressPromotionTaskletTest.java
@@ -1,0 +1,164 @@
+package cleanbreath.backend.batch;
+
+import cleanbreath.backend.entity.Address;
+import cleanbreath.backend.entity.DivisionArea;
+import cleanbreath.backend.entity.Path;
+import cleanbreath.backend.entity.pending.PendingAddress;
+import cleanbreath.backend.entity.pending.PendingPath;
+import cleanbreath.backend.repository.AddressRepository;
+import cleanbreath.backend.repository.PathRepository;
+import cleanbreath.backend.repository.pending.PendingAddressRepository;
+import cleanbreath.backend.repository.pending.PendingPathRepository;
+import cleanbreath.backend.repository.pending.SmokingAreaValidateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * AddressPromotionBatchConfig의 Tasklet 로직 단위 테스트.
+ * Given-When-Then 패턴 + FIRST 원칙 적용.
+ */
+@ExtendWith(MockitoExtension.class)
+class AddressPromotionTaskletTest {
+
+  @Mock private PendingAddressRepository pendingAddressRepository;
+  @Mock private PendingPathRepository pendingPathRepository;
+  @Mock private SmokingAreaValidateRepository validationRepository;
+  @Mock private AddressRepository addressRepository;
+  @Mock private PathRepository pathRepository;
+
+  @InjectMocks
+  private AddressPromotionBatchConfig batchConfig;
+
+  private Tasklet tasklet;
+
+  @BeforeEach
+  void setUp() {
+    // 임계값 설정
+    ReflectionTestUtils.setField(batchConfig, "promotionThreshold", 10);
+    tasklet = batchConfig.addressPromotionTasklet();
+  }
+
+  @Test
+  @DisplayName("승격 대상이 없으면 FINISHED를 반환하고 저장하지 않는다")
+  void shouldReturnFinishedWhenNoQualifiedAddresses() throws Exception {
+    // Given: 임계값을 충족하는 주소가 없음
+    given(pendingAddressRepository.findAddressesMeetingThreshold(10))
+        .willReturn(Collections.emptyList());
+
+    // When: Tasklet 실행
+    RepeatStatus status = tasklet.execute(null, null);
+
+    // Then: FINISHED 반환, Address 저장 호출 없음
+    assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+    verify(addressRepository, never()).save(any(Address.class));
+    verify(pathRepository, never()).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("임계값 충족 시 PendingAddress가 Address로 승격된다")
+  void shouldPromotePendingAddressToAddress() throws Exception {
+    // Given: 임계값을 충족하는 PendingAddress 1건 (PendingPath 포함)
+    PendingPath pendingPath = PendingPath.builder()
+        .divisionArea(DivisionArea.NON_SMOKING_ZONE)
+        .pathLat("37.123")
+        .pathLng("127.456")
+        .build();
+
+    PendingAddress pendingAddress = PendingAddress.builder()
+        .addressName("테스트 주소")
+        .buildingName("테스트 빌딩")
+        .addressPosLat(37.5665)
+        .addressPosLng(126.9780)
+        .addressCategory("공원")
+        .paths(List.of(pendingPath))
+        .build();
+
+    given(pendingAddressRepository.findAddressesMeetingThreshold(10))
+        .willReturn(List.of(pendingAddress));
+
+    Address savedAddress = Address.builder().id(1L).build();
+    given(addressRepository.save(any(Address.class))).willReturn(savedAddress);
+
+    // When: Tasklet 실행
+    RepeatStatus status = tasklet.execute(null, null);
+
+    // Then: Address 저장, Path 저장, Pending 데이터 삭제
+    assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+
+    ArgumentCaptor<Address> addressCaptor = ArgumentCaptor.forClass(Address.class);
+    verify(addressRepository).save(addressCaptor.capture());
+    Address captured = addressCaptor.getValue();
+    assertThat(captured.getAddressName()).isEqualTo("테스트 주소");
+    assertThat(captured.getBuildingName()).isEqualTo("테스트 빌딩");
+    assertThat(captured.getAddressPosLat()).isEqualTo(37.5665);
+    assertThat(captured.getAddressPosLng()).isEqualTo(126.9780);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<Path>> pathsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(pathRepository).saveAll(pathsCaptor.capture());
+    List<Path> savedPaths = pathsCaptor.getValue();
+    assertThat(savedPaths).hasSize(1);
+    assertThat(savedPaths.get(0).getDivisionArea())
+        .isEqualTo(DivisionArea.NON_SMOKING_ZONE);
+
+    // Pending 데이터 정리 검증
+    verify(validationRepository).deleteByPendingAddress(pendingAddress);
+    verify(pendingPathRepository).deleteByPendingAddress(pendingAddress);
+    verify(pendingAddressRepository).delete(pendingAddress);
+  }
+
+  @Test
+  @DisplayName("여러 건의 승격 대상이 있으면 모두 처리된다")
+  void shouldPromoteMultipleAddresses() throws Exception {
+    // Given: 임계값을 충족하는 PendingAddress 2건
+    PendingAddress address1 = PendingAddress.builder()
+        .addressName("주소1")
+        .buildingName("빌딩1")
+        .addressPosLat(37.0)
+        .addressPosLng(127.0)
+        .addressCategory("공원")
+        .paths(Collections.emptyList())
+        .build();
+
+    PendingAddress address2 = PendingAddress.builder()
+        .addressName("주소2")
+        .buildingName("빌딩2")
+        .addressPosLat(38.0)
+        .addressPosLng(128.0)
+        .addressCategory("학교")
+        .paths(Collections.emptyList())
+        .build();
+
+    given(pendingAddressRepository.findAddressesMeetingThreshold(10))
+        .willReturn(List.of(address1, address2));
+
+    given(addressRepository.save(any(Address.class)))
+        .willReturn(Address.builder().id(1L).build());
+
+    // When: Tasklet 실행
+    RepeatStatus status = tasklet.execute(null, null);
+
+    // Then: Address 2건 저장, Pending 2건 삭제
+    assertThat(status).isEqualTo(RepeatStatus.FINISHED);
+    verify(addressRepository, times(2)).save(any(Address.class));
+    verify(pendingAddressRepository, times(2)).delete(any(PendingAddress.class));
+  }
+}


### PR DESCRIPTION
## 개요
구역 상세 조회, 진위 투표 기능 및 투표 임계값 기반 주소 자동 승인 배치 작업을 구현했습니다.

## 변경 사항

### 1. Spring Batch 및 스케줄링 설정
- `build.gradle`: spring-boot-starter-batch, actuator 의존성 추가
- `application.yml`: batch 초기화, 임계값(20), cron 스케줄, actuator 설정
- `CleanBreathBackendApplication`: `@EnableScheduling` 활성화

### 2. 구역 상세 조회 및 진위 투표 기능
- `AreaValidationRequest`: clientToken, targetId 필드 및 UNIQUE 제약조건 추가 (중복 투표 방지)
- `PendingDto`: DetailResponse, ValidationVoteRequest DTO 추가
- `SmokingAreaValidateRepository`: 중복체크, truth/untruth 합계 쿼리 추가
- `PendingAddressService/Impl`: 상세 조회, 투표 로직 구현
- `PendingAddressController`: `GET /smokingArea/{id}`, `POST /smokingArea/{id}/vote` API 추가
- `ErrorCode`: DUPLICATE_VALIDATION_REQUEST 에러코드 추가

### 3. 주소 승인 배치 작업
- `AddressPromotionBatchConfig`: 임계값 기반 PendingAddress → Address 승인 배치 Job/Step 구성
- `AddressPromotionScheduler`: cron 기반 배치 스케줄러
- `PendingAddressRepository`: 임계값 이상 투표를 받은 주소 조회 쿼리

### 4. 테스트
- `AddressPromotionSchedulerTest`: 스케줄러 실행 테스트
- `AddressPromotionTaskletTest`: Tasklet 승인 로직 단위 테스트